### PR TITLE
API changes for assigning default zab leader and getting process counts

### DIFF
--- a/src/main/java/org/vanilladb/comm/client/VanillaCommClient.java
+++ b/src/main/java/org/vanilladb/comm/client/VanillaCommClient.java
@@ -23,7 +23,15 @@ import net.sf.appia.protocols.tcpcomplete.TcpCompleteLayer;
 
 public class VanillaCommClient implements P2pMessageListener, Runnable {
 	private static Logger logger = Logger.getLogger(VanillaCommClient.class.getName());
-
+	
+	public static int getServerCount() {
+		return ProcessView.SERVER_COUNT;
+	}
+	
+	public static int getClientCount() {
+		return ProcessView.CLIENT_COUNT;
+	}
+	
 	private VanillaCommClientListener listener;
 	private Channel p2pChannel;
 
@@ -57,14 +65,6 @@ public class VanillaCommClient implements P2pMessageListener, Runnable {
 	@Override
 	public void onRecvP2pMessage(int senderId, Serializable message) {
 		listener.onReceiveP2pMessage(ProcessView.toProcessType(senderId), ProcessView.toLocalId(senderId), message);
-	}
-	
-	public int getServerCount() {
-		return ProcessView.SERVER_COUNT;
-	}
-	
-	public int getClientCount() {
-		return ProcessView.CLIENT_COUNT;
 	}
 
 	private void setupP2pChannel(int globalSelfId) {

--- a/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionLayer.java
+++ b/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionLayer.java
@@ -9,7 +9,11 @@ import net.sf.appia.core.Session;
 
 public class ZabElectionLayer extends Layer {
 	
-	public ZabElectionLayer() {
+	private int defaultLeaderId;
+	
+	public ZabElectionLayer(int defaultLeaderId) {
+		this.defaultLeaderId = defaultLeaderId;
+		
 		// Events that the protocol will create
 		evProvide = new Class[] {
 			LeaderInit.class,
@@ -34,6 +38,6 @@ public class ZabElectionLayer extends Layer {
 
 	@Override
 	public Session createSession() {
-		return new ZabElectionSession(this);
+		return new ZabElectionSession(this, defaultLeaderId);
 	}
 }

--- a/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionSession.java
+++ b/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionSession.java
@@ -19,11 +19,14 @@ public class ZabElectionSession extends Session {
 	private static Logger logger = Logger.getLogger(ZabElectionSession.class.getName());
 	
 	private ProcessList processList;
+	private int defaultLeaderId;
 	private int leaderId;
 	private int epochId = 0;
 	
-	ZabElectionSession(Layer layer) {
+	ZabElectionSession(Layer layer, int defaultLeaderId) {
 		super(layer);
+		
+		this.defaultLeaderId = defaultLeaderId;
 	}
 	
 	@Override
@@ -103,7 +106,7 @@ public class ZabElectionSession extends Session {
 	
 	private void setFirstLeader(Channel channel) {
 		// Set the first leader
-		leaderId = processList.getSize() - 1;
+		leaderId = defaultLeaderId;
 		
 		if (logger.isLoggable(Level.FINE))
 			logger.fine("Initialize with leaderId = " + leaderId);


### PR DESCRIPTION
As the title, update the API so that we can assign the default leader for Zab.