### PR TITLE
Version 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To use this project as a library, we highly recommand to link via Maven. Please 
 <dependency>
   <groupId>org.vanilladb</groupId>
   <artifactId>comm</artifactId>
-  <version>0.2.4</version>
+  <version>0.2.5</version>
 </dependency>
 ```
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 0.2.5 (2021-07-22)
+
+### API Changes
+
+- Change `getServerCount()` and `getClientCount()` in `VanillaCommClient` and `VanillaCommServer` from non-static methods to static methods.
+- Update the constructor of `ZabElectionLayer` so that we can give it a machine ID as the default Zab leader.
+- Add a constructor for `VanillaCommServer` so that we can set the default Zab leader.
+
 ## Version 0.2.4 (2021-06-13)
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.vanilladb</groupId>
 	<artifactId>comm</artifactId>
-	<version>0.2.4</version>
+	<version>0.2.5</version>
 	<packaging>jar</packaging>
 
 	<name>vanillacomm</name>

--- a/src/main/java/org/vanilladb/comm/client/VanillaCommClient.java
+++ b/src/main/java/org/vanilladb/comm/client/VanillaCommClient.java
@@ -23,7 +23,15 @@ import net.sf.appia.protocols.tcpcomplete.TcpCompleteLayer;
 
 public class VanillaCommClient implements P2pMessageListener, Runnable {
 	private static Logger logger = Logger.getLogger(VanillaCommClient.class.getName());
-
+	
+	public static int getServerCount() {
+		return ProcessView.SERVER_COUNT;
+	}
+	
+	public static int getClientCount() {
+		return ProcessView.CLIENT_COUNT;
+	}
+	
 	private VanillaCommClientListener listener;
 	private Channel p2pChannel;
 
@@ -57,14 +65,6 @@ public class VanillaCommClient implements P2pMessageListener, Runnable {
 	@Override
 	public void onRecvP2pMessage(int senderId, Serializable message) {
 		listener.onReceiveP2pMessage(ProcessView.toProcessType(senderId), ProcessView.toLocalId(senderId), message);
-	}
-	
-	public int getServerCount() {
-		return ProcessView.SERVER_COUNT;
-	}
-	
-	public int getClientCount() {
-		return ProcessView.CLIENT_COUNT;
 	}
 
 	private void setupP2pChannel(int globalSelfId) {

--- a/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionLayer.java
+++ b/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionLayer.java
@@ -9,7 +9,11 @@ import net.sf.appia.core.Session;
 
 public class ZabElectionLayer extends Layer {
 	
-	public ZabElectionLayer() {
+	private int defaultLeaderId;
+	
+	public ZabElectionLayer(int defaultLeaderId) {
+		this.defaultLeaderId = defaultLeaderId;
+		
 		// Events that the protocol will create
 		evProvide = new Class[] {
 			LeaderInit.class,
@@ -34,6 +38,6 @@ public class ZabElectionLayer extends Layer {
 
 	@Override
 	public Session createSession() {
-		return new ZabElectionSession(this);
+		return new ZabElectionSession(this, defaultLeaderId);
 	}
 }

--- a/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionSession.java
+++ b/src/main/java/org/vanilladb/comm/protocols/zabelection/ZabElectionSession.java
@@ -19,11 +19,14 @@ public class ZabElectionSession extends Session {
 	private static Logger logger = Logger.getLogger(ZabElectionSession.class.getName());
 	
 	private ProcessList processList;
+	private int defaultLeaderId;
 	private int leaderId;
 	private int epochId = 0;
 	
-	ZabElectionSession(Layer layer) {
+	ZabElectionSession(Layer layer, int defaultLeaderId) {
 		super(layer);
+		
+		this.defaultLeaderId = defaultLeaderId;
 	}
 	
 	@Override
@@ -103,7 +106,7 @@ public class ZabElectionSession extends Session {
 	
 	private void setFirstLeader(Channel channel) {
 		// Set the first leader
-		leaderId = processList.getSize() - 1;
+		leaderId = defaultLeaderId;
 		
 		if (logger.isLoggable(Level.FINE))
 			logger.fine("Initialize with leaderId = " + leaderId);


### PR DESCRIPTION
### API Changes

- Change `getServerCount()` and `getClientCount()` in `VanillaCommClient` and `VanillaCommServer` from non-static methods to static methods.
- Update the constructor of `ZabElectionLayer` so that we can give it a machine ID as the default Zab leader.
- Add a constructor for `VanillaCommServer` so that we can set the default Zab leader.