### PR TITLE
Version 0.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.vanilladb</groupId>
 	<artifactId>comm</artifactId>
-	<version>0.2.5</version>
+	<version>0.2.6</version>
 	<packaging>jar</packaging>
 
 	<name>vanillacomm</name>


### PR DESCRIPTION
## Security Issue
1. Bump log4j from 1.2.17 to 2.17.1
2. Fit the new log4j apis